### PR TITLE
Fix vagrant environment bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,26 @@ TODOs
   [#4](https://github.com/pyvideo/richard-ansible/issues/4) if this affects you.
 * I do not know how to generate a password for SECRET_KEY. Please track 
   [#5](https://github.com/pyvideo/richard-ansible/issues/4) if this affects you.
+
+
+Vagrant
+=======
+
+To use the Vagrant environment, do:
+
+1. `pip install -r requirements.txt`
+2. `vagrant up`
+
+This uses Vagrant to create a vm with richard and its requirements set up.
+
+You can connect to richard in the vagrant environment by pointing your
+browser to `http://localhost:8000`.
+
+Helpful commands:
+
+* `vagrant up`: starts the environment
+* `vagrant ssh`: sshs into the environment as the vagrant user
+* `vagrant provision`: run ansible on the environment to pick up any
+  configuration management changes
+* `vagrant halt`: halts the environment
+* `vagrant destroy`: destroys the vm

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # `vagrant box outdated`. This is not recommended.
   # config.vm.box_check_update = false
 
+  # Need at least 512mb to compile lxml.
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "512"]
+  end
+
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ansible

--- a/roles/richard/tasks/main.yml
+++ b/roles/richard/tasks/main.yml
@@ -8,6 +8,9 @@
 - name: helpful links to nginx logs exist
   file: src=/var/log/nginx dest="{{ richard_dir }}/logs/nginx" state=link
 
+- name: make sure upstart uwsgi log file exists before we symlink it
+  file: path=/var/log/upstart/richard.uwsgi.log state=touch
+
 - name: helpful link to upstart uwsgi log exists
   file: src=/var/log/upstart/richard.uwsgi.log dest="{{ richard_dir }}/logs/richard.uwsgi.log" state=link
 


### PR DESCRIPTION
* add additional task to richard main.yml to touch the uwsgi log file
  before symlinking it because it doesn't exist, yet
* add requirements.txt file with ansible so you can create the
  virtual environment you need to run ansible
* tweak Vagrantfile setting the memory for the vm so that it has
  enough memory to compile lxml
* add some rough instructions to README.md that should get rewritten

Fixes #4